### PR TITLE
Fix typo attributes => attrs

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -33,7 +33,7 @@ function parse_blocks( $post ) {
 		$attributes = array_map( function ( $key ) use ( $block ) {
 			return [
 				'name'  => $key,
-				'value' => $block['attributes'][ $key ],
+				'value' => $block['attrs'][ $key ],
 			];
 		}, array_keys( $block['attrs'] ) );
 


### PR DESCRIPTION
This fixes a typo to better expose the value of the gutenberg block element