### PR TITLE
Patch WPGraphQL to provide terms on ContentNode

### DIFF
--- a/lib/wp-graphql-1.5.4/src/Connection/TermObjects.php
+++ b/lib/wp-graphql-1.5.4/src/Connection/TermObjects.php
@@ -197,7 +197,8 @@ class TermObjects {
 				}
 
 				register_graphql_connection( [
-					'fromType'       => $post_type_object->graphql_single_name,
+					// PATCH: https://github.com/wp-graphql/wp-graphql/pull/2026
+					'fromType'       => 'ContentNode',
 					'toType'         => 'TermNode',
 					'fromFieldName'  => 'terms',
 					'queryClass'     => 'WP_Term_Query',


### PR DESCRIPTION
See https://github.com/wp-graphql/wp-graphql/pull/2026. Eventually WPGraphQL's better handling of interfaces will allow us to remove this patch.