### PR TITLE
Catch self-closing HTML tags and better attributes for image component

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -125,7 +125,7 @@ function parse_blocks( $post_model ) {
 	$blocks = array_filter(
 		$blocks,
 		function( $block ) {
-			return $block['name'] != 'core/classic-editor' || $block['innerHTML'] != null;
+			return $block['name'] !== 'core/classic-editor' || $block['innerHTML'] !== null;
 		} 
 	);
 


### PR DESCRIPTION
This adds another layer for catching self-closing HTML tags like `<hr />` and adds some extra attributes for the `core/image` component.