### PR TITLE
Provide schema.org structured data when wp-parsely plugin is installed

### DIFF
--- a/parsely/parsely.php
+++ b/parsely/parsely.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package vip-bundle-decoupled
+ */
+
+namespace WPCOMVIP\Decoupled\Parsely;
+
+/**
+ * Registers Parse.ly fields in WPGraphQL.
+ *
+ * @return void
+ */
+function register_parsely_fields() {
+	if ( ! isset( $GLOBALS['parsely'] ) ) {
+		return;
+	}
+
+	register_graphql_field(
+		'NodeWithContentEditor',
+		'schemaOrgMeta',
+		[
+			'type'        => 'String',
+			'description' => 'Document schema for post',
+			'resolve'     => function ( $post_model ) {
+				$post    = get_post( $post_model->ID );
+				$options = $GLOBALS['parsely']->get_options();
+				$schema  = $GLOBALS['parsely']->construct_parsely_metadata( $options, $post );
+
+				// A JSON representation of the schema that can be embedded in a script
+				// tag by the decoupled frontend -- or optionally parsed and used to
+				// populate <meta> tags.
+				$json = wp_json_encode( $schema );
+
+				return empty( $json ) ? null : $json;
+			},
+		]
+	);
+}
+add_filter( 'init', __NAMESPACE__ . '\\register_parsely_fields', 10, 0 );

--- a/vip-decoupled.php
+++ b/vip-decoupled.php
@@ -61,6 +61,11 @@ if ( is_plugin_enabled( 'blocks' ) ) {
 require_once __DIR__ . '/cors/cors.php';
 
 /**
+ * Parse.ly
+ */
+require_once __DIR__ . '/parsely/parsely.php';
+
+/**
  * Enable decoupled previews
  */
 if ( is_plugin_enabled( 'preview' ) && is_decoupled() ) {


### PR DESCRIPTION
## Proof-of-concept against draft work

When the [WP-Parsely plugin](https://github.com/Parsely/wp-parsely/) is installed, this provides schema.org-compatible data that can be consumed by a decoupled front-end. This takes the form of stringified JSON, rather than a defined object type. The reason for this is that:

1. The data is likely to be consumed as a string, e.g.:

```
import React from 'react';
import { Helmet } from 'react-helmet';
 
export default function SchemaTag( props ) {
  return (
    <Helmet>
      <script
        dangerouslySetInnerHTML={{ __html: props.schemaOrgMeta }}
        type="application/ld+json"
      />
    </Helmet>
  );
}
```

2. This data is filterable, so a defined object type would be very fragile.

Example response:

```
{
  "data": {
    "posts": {
      "nodes": [
        {
          "link": "http://localhost:8888/2021/11/hello-world/",
          "schemaOrgMeta": "{\"@context\":\"http:\\/\\/schema.org\",\"@type\":\"NewsArticle\",\"mainEntityOfPage\":{\"@type\":\"WebPage\",\"@id\":\"http:\\/\\/localhost:8888\\/2021\\/11\\/hello-world\\/\"},\"headline\":\"Hello world!\",\"url\":\"http:\\/\\/localhost:8888\\/2021\\/11\\/hello-world\\/\",\"thumbnailUrl\":\"\",\"image\":{\"@type\":\"ImageObject\",\"url\":\"\"},\"dateCreated\":\"2021-11-11T23:22:43Z\",\"datePublished\":\"2021-11-11T23:22:43Z\",\"dateModified\":\"2021-11-11T23:22:43Z\",\"articleSection\":\"Uncategorized\",\"author\":[{\"@type\":\"Person\",\"name\":\"admin\"}],\"creator\":[\"admin\"],\"publisher\":{\"@type\":\"Organization\",\"name\":\"Test\",\"logo\":\"\"},\"keywords\":[]}"
        }
      ]
    }
  }
}
```