### PR TITLE
Add support for Gutenberg inner blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.2.0
+
+- **Content blocks:** _[BREAKING]_ By default, `innerHTML` no longer removes the wrapping tag. That behavior is still available by passing a field directive `innerHTML(removeWrappingTag: true)`. The field `outerHTML` is now deprecated, since `innerHTML` provides that behavior. [#38](https://github.com/Automattic/vip-decoupled-bundle/pull/38)
+- **WPGraphQL:** Updated to v1.6.7. [#34](https://github.com/Automattic/vip-decoupled-bundle/pull/34)
+
+## 0.1.0
+
+Initial release

--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -135,9 +135,10 @@ function process_content_blocks( $raw_blocks ) {
 			return array_merge(
 				get_content_block_html( $block['innerHTML'] ),
 				[
-					'attributes'  => get_content_block_attributes( $block ),
-					'innerBlocks' => process_content_blocks( $block['innerBlocks'] ),
-					'name'        => $block['blockName'],
+					'attributes'   => get_content_block_attributes( $block ),
+					'innerBlocks'  => process_content_blocks( $block['innerBlocks'] ),
+					'innerContent' => $block['innerContent'],
+					'name'         => $block['blockName'],
 				]
 			);
 		},
@@ -182,6 +183,10 @@ function register_types() {
 				'innerBlocks' => [
 					'type'        => [ 'list_of' => 'ContentBlock' ],
 					'description' => 'Inner blocks of this block',
+				],
+				'innerContent' => [
+					'type'        => [ 'list_of' => 'String' ],
+					'description' => 'List of string fragments and null markers where inner blocks were found',
 				],
 				'innerHTML'   => [
 					'type'        => 'String',

--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -153,6 +153,7 @@ function process_content_blocks( $raw_blocks ) {
 					'attributes'   => $block['attrs'],
 					'innerBlocks'  => process_content_blocks( $block['innerBlocks'] ),
 					'innerContent' => $block['innerContent'],
+					'innerHTML'    => $block['innerHTML'],
 					'name'         => $block['blockName'],
 				]
 			);

--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -78,10 +78,11 @@ function transform_block_attributes( $block ) {
 \add_filter( 'vip_decoupled_graphql_content_block', __NAMESPACE__ . '\\transform_block_attributes', 10, 1 );
 
 /**
- * Provide the inner HTML in several different formats. The block resolver will
- * choose the most appropriate based on field arguments. Also provide the
- * wrapping tag name, which can allow the front-end implementor to delegate tag
- * creation to a component.
+ * Parse the inner HTML and provide a version with the wrapping tag pulled out
+ * into a seperate tagName property. The block resolver will deliver either the
+ * original or the "unwrapped" version based on the passed field arguments. The
+ * wrapping tag name allows the front-end implementor to delegate tag creation
+ * to a component.
  *
  * @param  string $html Inner HTML of block.
  * @return array

--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -155,6 +155,7 @@ function process_content_blocks( $raw_blocks ) {
 					'innerContent' => $block['innerContent'],
 					'innerHTML'    => $block['innerHTML'],
 					'name'         => $block['blockName'],
+					'outerHTML'    => $block['innerHTML'],
 				]
 			);
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "automattic/vipwpcs": "^2.3",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^7",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "scripts": {
         "phpcs": "phpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a17ced14c6cb1e714e40c412ddbf19c9",
+    "content-hash": "a1c9b8003c0aca004ebd02a5d0a8bba3",
     "packages": [],
     "packages-dev": [
         {
@@ -2152,6 +2152,67 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-11-23T01:37:03+00:00"
         }
     ],
     "aliases": [],

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Blocks
+ *
+ * @package vip-bundle-decoupled
+ */
+
+namespace WPCOMVIP\Decoupled\Blocks\Tests;
+
+use WP_UnitTestCase;
+use function WPCOMVIP\Decoupled\Blocks\parse_inner_html;
+
+/**
+ * Blocks
+ */
+class BlocksTest extends WP_UnitTestCase {
+	public function contentBlockHtmlDataProvider() {
+		return [
+			// Null
+			[
+				null,
+				[
+					'innerHTMLUnwrapped' => null,
+					'tagName'            => null,
+				],
+			],
+			// No wrapping tag
+			[
+				'Hello, world!',
+				[
+					'innerHTMLUnwrapped' => 'Hello, world!',
+					'tagName'            => null,
+				],
+			],
+			// Simple wrapping tag
+			[
+				'<div>Test</div>',
+				[
+					'innerHTMLUnwrapped' => 'Test',
+					'tagName'            => 'div',
+				],
+			],
+			// Simple self-closing tag
+			[
+				'<div />',
+				[
+					'innerHTMLUnwrapped' => null,
+					'tagName'            => 'div',
+				],
+			],
+			// Wrapping tag with attributes and nested HTML
+			[
+				'<aside id="aside"><p>Hello, world!</p></aside>',
+				[
+					'innerHTMLUnwrapped' => '<p>Hello, world!</p>',
+					'tagName'            => 'aside',
+				],
+			],
+			// Wrapping tag with nested HTML of the same kind
+			[
+				'<div><div>A little bit me</div><div>A little bit you</div></div>',
+				[
+					'innerHTMLUnwrapped' => '<div>A little bit me</div><div>A little bit you</div>',
+					'tagName'            => 'div',
+				],
+			],
+			// Sibling elements (no wrapping tag) should be left alone
+			[
+				'<div>A little bit me</div><div>A little bit you</div>',
+				[
+					'innerHTMLUnwrapped' => null,
+					'tagName'            => null,
+				],
+			],
+			// Malformed HTML should be left alone
+			[
+				'<div>Hello, world!',
+				[
+					'innerHTMLUnwrapped' => null,
+					'tagName'            => null,
+				],
+			],
+		];
+	}
+
+	/**
+	 * parse_inner_html() extracts inner HTML from block HTML.
+	 *
+	 * @dataProvider contentBlockHtmlDataProvider
+	 */
+	public function test_parse_inner_html( $input_html, $expected_output ) {
+		$output = parse_inner_html( $input_html );
+		$this->assertEquals( $expected_output, $output );
+
+		// Make the same assertion with white space surrounding the input.
+		$wrapped_input_html = sprintf( "\n\n   %s   \n\n", $input_html );
+		$output = parse_inner_html( $wrapped_input_html );
+		$this->assertEquals( $expected_output, $output );
+	}
+}
+


### PR DESCRIPTION
Add support for Gutenberg inner blocks in `contentBlocks` output. This required a little refactoring to make the process function callable recursively.

A classic use case is columns:

```json
{
  "name": "core/columns",
  "tagName": null,
  "innerHTML": null,
  "outerHTML": null,
  "attributes": [],
  "innerBlocks": [
    {
      "name": "core/column",
      "tagName": "div",
      "innerHTML": "",
      "outerHTML": "<div class=\"wp-block-column\"></div>",
      "attributes": [],
      "innerBlocks": [
        {
          "name": "core/paragraph",
          "tagName": "p",
          "innerHTML": "<strong>column 1</strong>",
          "outerHTML": "<p><strong>column 1</strong></p>",
          "attributes": []
        }
      ]
    },
    {
      "name": "core/column",
      "tagName": "div",
      "innerHTML": "",
      "outerHTML": "<div class=\"wp-block-column\"></div>",
      "attributes": [],
      "innerBlocks": [
        {
          "name": "core/paragraph",
          "tagName": "p",
          "innerHTML": "<em>column 2</em>",
          "outerHTML": "<p><em>column 2</em></p>",
          "attributes": []
        }
      ]
    }
  ]
}
```

Note that fetching nested inner blocks requires an explicit query to a fixed depth:

```gql
fragment ContentBlockParts {
  name
  tagName
  innerHTML
  outerHTML
  attributes {
    name
    value
  }
}

query MyQuery {
  posts {
    nodes {
      title
      contentBlocks {
        blocks {
          ...ContentBlockParts
          innerBlocks {
            ...ContentBlockParts
            innerBlocks {
              ...ContentBlockParts
            }
          }
        }
      }
    }
  }
}
```