### PR TITLE
Add support for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
         "phpcs-fix": "phpcbf",
         "test": "phpunit"
     },
-    "license": "GPL-2.0-or-later"
+    "license": "GPL-2.0-or-later",
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -215,9 +215,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -2224,5 +2221,5 @@
     "platform-dev": {
         "php": ">=7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Composer 2.2 introduces [more secure plugin execution](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) and this PR adds support for it.
