### PR TITLE
Update README with a new test execution script, and instructions for running it

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ composer test-local
 
 ### Troubleshooting
 
-In the event that you are facing any docker container problems, the following should likely be helpful in re-creating those docker containers:
+In the event that you are facing any docker container related problems, the following would be helpful in re-creating those docker containers:
 
 ```sh
 wp-env destroy

--- a/README.md
+++ b/README.md
@@ -68,26 +68,27 @@ See our [Next.js boilerplate][nextjs-boilerplate] for an example of how to use a
 
 This plugin overrides WordPress's native preview functionality and securely sends you to your decoupled frontend to preview your content. This ensures that your preview content has parity with your published content. It works by issuing a one-time use token, locked to a specific post, that can be redeemed by the frontend to obtain preview content for that post.
 
-This plugin currently only works with our Next.js boilerplate and should be disabled if you are not using it.
+This plugin currently only works with our Next.js boilerplate and should be disabled if you are not using it. 
 
 ## Running unit tests
 
-First, start a local environment using `wp-env`:
+### Pre-requisites
+
+In order to run the unit tests, you will need the following:
+
+- [Docker](https://www.docker.com/get-started)
+- [Composer](https://getcomposer.org/download/)
+- [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)
+- PHP <= 7.4
+
+### Commands to run the tests
+
+Run the following in order to install the right php packages, start a local wordpress environment and run the tests against it:
 
 ```sh
 composer install
 wp-env start
-wp-env run tests-wordpress bash
-```
-
-Run tests in the `tests-wordpress` container:
-
-```sh
-apt-get update
-apt-get install -y mariadb-client subversion
-./wp-content/plugins/vip-decoupled-bundle/bin/install-wp-tests.sh tests-wordpress root password tests-mysql latest
-cd wp-content/plugins/vip-decoupled-bundle
-./vendor/bin/phpunit
+wp-env run tests-wordpress ./wp-content/plugins/vip-decoupled-bundle/bin/run-tests.sh
 ```
 
 [graphql]: https://graphql.org

--- a/README.md
+++ b/README.md
@@ -88,8 +88,19 @@ Run the following in order to install the right php packages, start a local word
 ```sh
 composer install
 wp-env start
-wp-env run tests-wordpress ./wp-content/plugins/vip-decoupled-bundle/bin/run-tests.sh
+composer test-local
 ```
+
+### Troubleshooting
+
+In the event that you are facing any docker container problems, the following should likely be helpful in re-creating those docker containers:
+
+```sh
+wp-env destroy
+docker volume prune
+```
+
+It's also helpful to delete all the images pertaining to what was destroyed above.
 
 [graphql]: https://graphql.org
 [nextjs-boilerplate]: https://github.com/Automattic/vip-go-nextjs-skeleton

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-apt-get update
-apt-get install -y mariadb-client subversion
-cd wp-content/plugins/vip-decoupled-bundle
-./bin/install-wp-tests.sh tests-wordpress root password tests-mysql latest
-./vendor/bin/phpunit

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y mariadb-client subversion
+cd wp-content/plugins/vip-decoupled-bundle
+./bin/install-wp-tests.sh tests-wordpress root password tests-mysql latest
+./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "scripts": {
         "phpcs": "phpcs",
         "phpcs-fix": "phpcbf",
-        "test": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/vip-decoupled-bundle/phpunit.xml.dist --verbose'"
+        "test": "phpunit",
+        "test-local": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/vip-decoupled-bundle/phpunit.xml.dist'"
     },
     "license": "GPL-2.0-or-later",
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,13 @@
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "phpunit/phpunit": "^7",
-        "yoast/phpunit-polyfills": "^1.0"
+        "yoast/phpunit-polyfills": "^1.0",
+        "wp-phpunit/wp-phpunit": "^5.9"
     },
     "scripts": {
         "phpcs": "phpcs",
         "phpcs-fix": "phpcbf",
-        "test": "phpunit"
+        "test": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/vip-decoupled-bundle/phpunit.xml.dist --verbose'"
     },
     "license": "GPL-2.0-or-later",
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1c9b8003c0aca004ebd02a5d0a8bba3",
+    "content-hash": "71007a0f9c6b192017123c43b74ebcd6",
     "packages": [],
     "packages-dev": [
         {
@@ -2149,6 +2149,54 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "5.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "02d98f9d5f15442489b5d98c1f4c486901e3e110"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/02d98f9d5f15442489b5d98c1f4c486901e3e110",
+                "reference": "02d98f9d5f15442489b5d98c1f4c486901e3e110",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://github.com/wp-phpunit/docs",
+                "issues": "https://github.com/wp-phpunit/issues",
+                "source": "https://github.com/wp-phpunit/wp-phpunit"
+            },
+            "time": "2022-01-25T20:37:14+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,20 +5,34 @@
  * @package Vip_Decoupled_Bundle
  */
 
+// Require composer dependencies.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
 if ( PHP_MAJOR_VERSION >= 8 ) {
 	echo 'The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285' . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 
+// Determine the tests directory (from a WP dev checkout).
+// Try the WP_TESTS_DIR environment variable first.
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
+// Next, try the WP_PHPUNIT composer package.
 if ( ! $_tests_dir ) {
-	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+	$_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
 }
 
-if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
-	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
+// See if we're installed inside an existing WP dev instance.
+if ( ! $_tests_dir ) {
+	$_try_tests_dir = __DIR__ . '/../../../../../tests/phpunit';
+	if ( file_exists( $_try_tests_dir . '/includes/functions.php' ) ) {
+		$_tests_dir = $_try_tests_dir;
+	}
+}
+
+// Fallback.
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
 // Give access to tests_add_filter() function.


### PR DESCRIPTION
### Description

- Add a new test execution script that replaces the block of commands that had to be run by going into the docker container, by now just using the `wp-env run` command instead
- Add some pre-requisites to better understand what tooling is needed before trying to run the tests, along with how to run the new script as well