### PR TITLE
Allow preview tokens to be multiuse with filter

### DIFF
--- a/preview/README.md
+++ b/preview/README.md
@@ -1,0 +1,22 @@
+# WPGraphQL Preview
+
+This plugin overrides WordPress's native preview functionality and securely sends you to your decoupled frontend to preview your content. This ensures that your preview content has parity with your published content. It works by issuing a one-time use token, locked to a specific post, that can be redeemed by the frontend to obtain preview content for that post.
+
+This plugin currently only works with our Next.js boilerplate and should be disabled if you are not using it. 
+
+## Filters
+
+### `vip_decoupled_token_lifetime`
+
+Default: `3600` (one hour in seconds)
+
+Filter the token lifetime (expiration window).
+
+### `vip_decoupled_token_expire_on_use`
+
+Default: `true`
+
+Filter whether to expire the token on use. By default, tokens are "one-time use" and we mark them as expired as soon as they are used. If you want to allow tokens to be used more than once, filter this value to `false`.
+
+Understand the security implications of this change: Within the expiration window, tokens / preview URLs become bearer tokens for viewing the associated draft post preview. Anyone who possesses them will be able to view and share the preview, even if they are not an authorized WordPress user.
+

--- a/preview/token.php
+++ b/preview/token.php
@@ -98,7 +98,26 @@ function validate_token( $token, $post_id, $action ) {
 
 		// Check if token matches. If it does, mark as expired.
 		if ( ! $is_expired && $token === $saved['token'] && $action === $saved['action'] ) {
-			$is_expired = true;
+			/**
+			 * Filter whether to expire the token on use. By default, tokens are
+			 * "one-time use" and we mark them as expired as soon as they are used.
+			 * If you want to allow tokens to be used more than once, filter this
+			 * value to `false`. Understand the security implications of this change:
+			 * Within the expiration window, tokens / preview URLs become bearer
+			 * tokens for viewing the associated draft post preview. Anyone who
+			 * possesses them will be able to view and share the preview, even if they
+			 * are not an authorized WordPress user, and could share them with anyone
+			 * else.
+			 *
+			 * @param bool   $expire_on_use Whether the token should expire on use.
+			 * @param string $action        Action that will be performed with this token.
+			 */
+			$expire_on_use = apply_filters( 'vip_decoupled_token_expire_on_use', true, $action );
+
+			if ( $expire_on_use ) {
+				$is_expired = true;
+			}
+
 			$is_valid   = true;
 		}
 

--- a/preview/token.php
+++ b/preview/token.php
@@ -118,7 +118,7 @@ function validate_token( $token, $post_id, $action ) {
 				$is_expired = true;
 			}
 
-			$is_valid   = true;
+			$is_valid = true;
 		}
 
 		// Delete expired tokens.


### PR DESCRIPTION
By default, preview tokens are one-time use (expire on use). Some workflows may be ok with a reduced security approach that allows them to share preview URLs with others—whether they are authorized WordPress users or not.

Introduce a filter that allows the implementor to disable expire on use behavior. This means the token will be valid until expiration.
