### PR TITLE
Detect and document mismatched `home` / `siteurl` base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,27 @@ This plugin bundle provides a number of plugins to help you quickly setup a deco
 
 ## Setting your home URL
 
-WordPress needs to know the address of your frontend so that it can point permalinks, feed links, and other URLs to the correct destination. WordPress uses the `home` option for this, but by default it is set to the same address that WordPress is served from. You must update it to the address of your decoupled frontend.
+WordPress needs to know the address of your frontend so that it can point previews, permalinks, feed links, and other URLs to the correct destination. WordPress uses the `home` option for this, but by default it is set to the same address that WordPress is served from. You must update it to the address of your decoupled frontend.
 
-You can make this change in the Dashboard at Settings > General > Site Address (URL). Alternatively, you can define the `WP_HOME` constant in your `wp-config.php` or [`vip-config.php` on VIP][vip-config]:
+**Be careful:** In the Dashboard, WordPress labels the `home` option inconsistently and in ways that can be confusing and misleading. A related but separate option named `siteurl` governs where WordPress serves the Dashboard and other core functionality. You should not edit `siteurl`; however, WordPress sometimes labels the `home` option as "Site Address (URL)." The instructions below will help you correctly update the `home` option. This plugin also displays an admin notice when `home` is configured incorrectly.
+
+For traditional, single-site WordPress instances, update the `home` option Dashboard at Settings > General > Site Address (URL). Alternatively, you can define the `WP_HOME` constant in your `wp-config.php` or [`vip-config.php` on VIP][vip-config]:
 
 ```php
 define( 'WP_HOME', 'https://my-decoupled-frontend.example.com' );
 ```
 
-See [WordPress documentation for other options](https://wordpress.org/support/article/changing-the-site-url/#changing-the-site-url). **Note:** For multisite installs, you will need to update the `home` option or define a `WP_{$blog_id}_HOME` constant for each site that uses this plugin.
+For multisite instances, the `home` option must be set for each subsite that uses this plugin. Set it at "Network Admin > Sites > [Subsite] > Settings > Home". Alternatively, define a `WP_{$blog_id}_HOME` constant for each site that uses this plugin, e.g.:
 
-That's all the configuration that's needed to support your decoupled frontend. If you are using VIP's Next.js boilerplate, [head over to the README][nextjs-boilerplate] to get your frontend up and running.
+```php
+define( 'WP_2_HOME', 'https://my-decoupled-frontend.example.com' );
+```
 
 ## Settings and sub-plugins
 
 This plugin provides a settings page in the WordPress Dashboard at Settings > VIP Decoupled. There, you'll find your GraphQL endpoint. You can also see (and optionally disable) the "sub-plugins", described below, that this plugin provides.
+
+That's all the configuration that's needed to support your decoupled frontend. If you are using VIP's Next.js boilerplate, [head over to the README][nextjs-boilerplate] to get your frontend up and running.
 
 ### WPGraphQL
 

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -17,3 +17,86 @@ function is_decoupled() {
 
 	return $frontend !== $backend;
 }
+
+/**
+ *
+ * @return bool
+ */
+function is_misconfigured_multisite() {
+	if ( ! is_multisite() ) {
+		return false;
+	}
+
+	$frontend_path = wp_parse_url( home_url(), PHP_URL_PATH );
+	$backend_path  = wp_parse_url( site_url(), PHP_URL_PATH );
+
+	$frontend_path = null === $frontend_path ? '/' : $frontend_path;
+	$backend_path  = null === $backend_path ? '/' : $backend_path;
+
+	return $frontend_path !== $backend_path;
+}
+
+/**
+ * Render admin notices if there are compatibility issues.
+ *
+ * @return void
+ */
+function render_admin_notices() {
+	$administration_name = 'Settings > General > Site Address (URL)';
+	$administration_url  = admin_url( 'options-general.php' );
+
+	// Multisite options are a bit different.
+	if ( is_multisite() ) {
+		$site_id             = get_current_blog_id();
+		$administration_name = sprintf( 'Network Admin > Sites > Site %d > Settings > Home', $site_id );
+		$administration_url  = network_admin_url( sprintf( 'site-settings.php?id=%d', $site_id ) );
+	}
+
+	// If the home URL is the same as the site URL, then the site is not decoupled
+	// and features like preview will not work.
+	if ( ! is_decoupled() ) {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<h3>Additional configuration is needed to support your decoupled frontend</h3>
+			<p><strong>This WordPress site’s <code>home_url()</code> does not point to a decoupled frontend.</strong> Previewing, permalinks, and other features will not work.</p>
+			<table class="widefat importers">
+				<tbody id="the-list">
+					<tr class="source-other">
+						<td><code>home_url()</code></td>
+						<td><?php echo esc_html( home_url() ); ?></td>
+					</tr>
+					<tr class="source-other">
+						<td><code>site_url()</code></td>
+						<td><?php echo esc_html( site_url() ); ?></td>
+					</tr>
+				</tbody>
+			</table>
+			<p>Please update <a href="<?php echo esc_url( $administration_url ); ?>"><?php echo esc_html( $administration_name ); ?></a> to point to the base URL of your decoupled frontend.</p>
+		</div>
+		<?php
+	}
+
+	// Multisite options are a bit different.
+	if ( is_misconfigured_multisite() ) {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<h3>Decoupled multisite configuration error</h3>
+			<p><strong>When using multisite WordPress with a decoupled frontend, the base paths of the backend and frontend must match.</strong> This misconfiguration will lead to serious issues with the operation of WordPress.</p>
+			<table class="widefat importers">
+				<tbody id="the-list">
+					<tr class="source-other">
+						<td><code>home_url()</code></td>
+						<td><?php echo esc_html( home_url() ); ?></td>
+					</tr>
+					<tr class="source-other">
+						<td><code>site_url()</code></td>
+						<td><?php echo esc_html( site_url() ); ?></td>
+					</tr>
+				</tbody>
+			</table>
+			<p>Please update <a href="<?php echo esc_url( $administration_url ); ?>"><?php echo esc_html( $administration_name ); ?></a> so that the path of "Home" matches the path of "Siteurl".</p>
+		</div>
+		<?php
+	}
+}
+add_action( 'admin_notices', __NAMESPACE__ . '\\render_admin_notices' );

--- a/vip-decoupled.php
+++ b/vip-decoupled.php
@@ -17,7 +17,6 @@
 
 namespace WPCOMVIP\Decoupled;
 
-use function WPCOMVIP\Decoupled\Admin\is_decoupled;
 use function WPCOMVIP\Decoupled\Settings\is_plugin_enabled;
 
 /**
@@ -67,30 +66,6 @@ if ( is_plugin_enabled( 'registration' ) ) {
  * Adjust resource URLs
  */
 require_once __DIR__ . '/urls/urls.php';
-
-/**
- * Render admin notices if there are compatibility issues.
- *
- * @return void
- */
-function render_admin_notices() {
-	// If the home URL is the same as the site URL, then the site is not decoupled
-	// and features like preview will not work.
-	$administration_url = admin_url( 'options-general.php' );
-	if ( ! is_decoupled() ) {
-
-		if ( is_multisite() ) {
-			$administration_url = network_admin_url( 'site-settings.php?id=' . get_current_blog_id() );
-		}
-
-		?>
-		<div class="notice notice-error is-dismissible">
-			<p><strong>The VIP Decoupled plugin is active but the <code>home</code> option does not point to a decoupled frontend.</strong> Previewing and other features will not work. Please set "Site Address (URL)" in <a href="<?php echo esc_url( $administration_url ); ?>">Settings &gt; General</a> to point to the base URL of your decoupled frontend.</p>
-		</div>
-		<?php
-	}
-}
-add_action( 'admin_notices', __NAMESPACE__ . '\\render_admin_notices' );
 
 /**
  * Force-enable schema introspection. If schema introspection is disabled, code


### PR DESCRIPTION
When running a decoupled site against a multisite instance, a mismatched `home` / `siteurl` base path can cause severe issues, including REST API `404`s. This basically makes WordPress inoperable.

Detect and document this issue. When present, loudly warn:

<img width="927" alt="Screen Shot 2022-05-03 at 2 24 00 PM" src="https://user-images.githubusercontent.com/739304/166854683-316f7280-8f9e-46d2-9030-c02c9cc8dd7e.png">

Additionally, improve the existing warning when `home` is not pointed to a decoupled frontend:

<img width="926" alt="Screen Shot 2022-05-03 at 2 21 04 PM" src="https://user-images.githubusercontent.com/739304/166854680-3b06b791-18c1-4121-9c22-37bd170d20fc.png">

