### PR TITLE
Fix graphql endpoint rewrite

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,5 +4,8 @@
 	],
 	"config": {
 		"WP_HOME": "http://localhost:3000"
+	},
+	"mappings": {
+		".htaccess": ".wp-env/.htaccess"
 	}
 }

--- a/.wp-env/.htaccess
+++ b/.wp-env/.htaccess
@@ -1,0 +1,11 @@
+# Allow rewrites for GraphQL endpoint
+
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>


### PR DESCRIPTION
See https://github.com/Automattic/vip-go-nextjs-skeleton/pull/100 for the same fix in the NextJS skeleton. As of recently, the environment created by `wp-env` does not allow `.htaccess` writes which breaks the `/graphql` endpoint. This maps an `.htaccess` file via `.wp-env.json` config to fix the issue.