### PR TITLE
Add Customisable Maximum Token Lifetime

### DIFF
--- a/preview/token.php
+++ b/preview/token.php
@@ -25,8 +25,20 @@ function get_meta_key() {
  */
 function get_token_lifetime_in_seconds( $action, $post_id ) {
 	$default_lifetime = HOUR_IN_SECONDS;
+	$default_max_lifetime = 3 * HOUR_IN_SECONDS;
 
-	$max_lifetime = apply_filters( 'vip_decoupled_max_token_lifetime', 3 * HOUR_IN_SECONDS, $action, $post_id );
+	/**
+	 * Filter the maximum allowed token lifetime.
+	 *
+	 * This filter allows external plugins or custom code to modify the maximum
+	 * lifetime of a token. It provides a way to enforce an upper limit on the 
+	 * duration for which a token remains valid.
+	 *
+	 * @param int    $default_max_lifetime The default maximum token lifetime in seconds.
+	 * @param string $action               Action that will be performed with this token.
+	 * @param int    $post_id              Post ID.
+	 */
+	$max_lifetime = apply_filters( 'vip_decoupled_max_token_lifetime', $default_max_lifetime, $action, $post_id );
 
 	/**
 	 * Filter the allowed token lifetime.

--- a/preview/token.php
+++ b/preview/token.php
@@ -41,7 +41,6 @@ function get_token_lifetime_in_seconds( $action, $post_id ) {
 	 * @param int    $default_max_lifetime The default maximum token lifetime in seconds.
 	 * @param string $action               Action that will be performed with this token.
 	 * @param int    $post_id              Post ID.
-	 * 
 	 */
 	$max_lifetime = apply_filters( 'vip_decoupled_max_token_lifetime', $default_max_lifetime, $action, $post_id );
 

--- a/preview/token.php
+++ b/preview/token.php
@@ -25,7 +25,8 @@ function get_meta_key() {
  */
 function get_token_lifetime_in_seconds( $action, $post_id ) {
 	$default_lifetime = HOUR_IN_SECONDS;
-	$max_lifetime     = 3 * HOUR_IN_SECONDS;
+
+	$max_lifetime = apply_filters( 'vip_decoupled_max_token_lifetime', 3 * HOUR_IN_SECONDS, $action, $post_id );
 
 	/**
 	 * Filter the allowed token lifetime.

--- a/preview/token.php
+++ b/preview/token.php
@@ -33,10 +33,15 @@ function get_token_lifetime_in_seconds( $action, $post_id ) {
 	 * This filter allows external plugins or custom code to modify the maximum
 	 * lifetime of a token. It provides a way to enforce an upper limit on the 
 	 * duration for which a token remains valid.
+	 * 
+	 * Understand the security implications of this change:
+	 * the longer the token lifetime, the more security risk you bear with a compromised token.
+	 * Extend the maximum lifetime with caution.
 	 *
 	 * @param int    $default_max_lifetime The default maximum token lifetime in seconds.
 	 * @param string $action               Action that will be performed with this token.
 	 * @param int    $post_id              Post ID.
+	 * 
 	 */
 	$max_lifetime = apply_filters( 'vip_decoupled_max_token_lifetime', $default_max_lifetime, $action, $post_id );
 

--- a/preview/token.php
+++ b/preview/token.php
@@ -24,7 +24,7 @@ function get_meta_key() {
  * @return int
  */
 function get_token_lifetime_in_seconds( $action, $post_id ) {
-	$default_lifetime = HOUR_IN_SECONDS;
+	$default_lifetime     = HOUR_IN_SECONDS;
 	$default_max_lifetime = 3 * HOUR_IN_SECONDS;
 
 	/**


### PR DESCRIPTION
This PR updates the token.php file to allow external plugins to set a custom maximum token lifetime.

**Changes include**:
- New Filter Added: Introduced the vip_decoupled_max_token_lifetime filter.
- Updated Function: Modified get_token_lifetime_in_seconds to use this filter, allowing the maximum token lifetime ($max_lifetime) to be adjusted externally.

**Impact**:
Allows more flexibility in setting token lifetimes through external plugins.
Maintains default maximum lifetime unless specifically overridden.
