### PR TITLE
Add preview URL filter

### DIFF
--- a/preview/preview.php
+++ b/preview/preview.php
@@ -34,7 +34,7 @@ function redirect_to_preview() {
 			exit;
 		}
 
-		$preview_url = home_url( sprintf( '/preview/%s/%d', $preview_token, $post->ID ) );
+		$preview_url_home = home_url( sprintf( '/preview/%s/%d', $preview_token, $post->ID ) );
 		/**
 		 * Filter preview URL before redirect.
 		 *
@@ -42,10 +42,20 @@ function redirect_to_preview() {
 		 * @param  $preview_token   Token used to view the preview.
 		 * @param  $post_id         ID of the post being previewed.
 		 */
-		$preview_url = apply_filters( 'vip_decoupled_preview_url', $preview_url, $preview_token, $post->ID );
+		$preview_url = apply_filters( 'vip_decoupled_preview_url', $preview_url_home, $preview_token, $post->ID );
 
-		wp_redirect( $preview_url, 302 );
-		exit;
+		if ( $preview_url === $preview_url_home ) {
+			// Use wp_safe_redirect by default, as this can potentially stop a malicious redirect.
+			wp_safe_redirect( $preview_url, 302 );
+			exit;
+		} else {
+			// If the URL was modified by the above filter, use wp_redirect to allow previewing on another domain.
+
+			// Allow cross-domain redirects if the filter is used.
+			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+			wp_redirect( $preview_url, 302 );
+			exit;
+		}
 	}
 }
 add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_to_preview', 10, 0 );

--- a/preview/preview.php
+++ b/preview/preview.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * The preview module.
- * 
+ *
  * @package vip-bundle-decoupled
  */
 
@@ -35,7 +35,16 @@ function redirect_to_preview() {
 		}
 
 		$preview_url = home_url( sprintf( '/preview/%s/%d', $preview_token, $post->ID ) );
-		wp_safe_redirect( $preview_url, 302 );
+		/**
+		 * Filter preview URL before redirect.
+		 *
+		 * @param  $preview_url     Generated preview URL, based on home_url().
+		 * @param  $preview_token   Token used to view the preview.
+		 * @param  $post_id         ID of the post being previewed.
+		 */
+		$preview_url = apply_filters( 'vip_decoupled_preview_url', $preview_url, $preview_token, $post->ID );
+
+		wp_redirect( $preview_url, 302 );
 		exit;
 	}
 }

--- a/preview/preview.php
+++ b/preview/preview.php
@@ -49,10 +49,7 @@ function redirect_to_preview() {
 			wp_safe_redirect( $preview_url, 302 );
 			exit;
 		} else {
-			// If the URL was modified by the above filter, use wp_redirect to allow previewing on another domain.
-
-			// Allow cross-domain redirects if the filter is used.
-			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Allow cross-domain redirects if the filter is used.
 			wp_redirect( $preview_url, 302 );
 			exit;
 		}


### PR DESCRIPTION
## Description

See discussion in https://github.com/Automattic/vip-decoupled-bundle/issues/70. It can be difficult to set up `home_url()` to point to a decoupled front end for previews, but ensure WordPress continues to function normally. For flexibility, we're adding this filter to modify the preview URL destination separately:

```php
/**
 * Filter preview URL before redirect.
 *
 * @param  $preview_url     Generated preview URL, based on home_url().
 * @param  $preview_token   Token used to view the preview.
 * @param  $post_id         ID of the post being previewed.
 */
$preview_url = apply_filters( 'vip_decoupled_preview_url', $preview_url, $preview_token, $post->ID );
```

Note that `wp_safe_redirect()` has also been changed to `wp_redirect()`, as the former [will not allow redirection outside of the home domain](https://developer.wordpress.org/reference/functions/wp_safe_redirect/).

