### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+
+- [**Add preview URL filter**](https://github.com/Automattic/vip-decoupled-bundle/pull/81:) Adds the ability to modify preview URL destinations.
+- [**Update VIP Block Data API v1.2.1**](https://github.com/Automattic/vip-decoupled-bundle/pull/82): Update the VIP Block Data API to `1.2.1`, which [supports `rich-text` attributes](https://github.com/Automattic/vip-block-data-api/releases/tag/1.2.1) in WordPress 6.5.
+
 ## 1.2.0
 
 - [**VIP Block Data API**](https://github.com/Automattic/vip-block-data-api) plugin added to bundle as an alternative to Content Blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1
 
-- [**Add preview URL filter**](https://github.com/Automattic/vip-decoupled-bundle/pull/81:) Adds the ability to modify preview URL destinations.
+- [**Add preview URL filter**](https://github.com/Automattic/vip-decoupled-bundle/pull/81): Adds the ability to modify preview URL destinations.
 - [**Update VIP Block Data API v1.2.1**](https://github.com/Automattic/vip-decoupled-bundle/pull/82): Update the VIP Block Data API to `1.2.1`, which [supports `rich-text` attributes](https://github.com/Automattic/vip-block-data-api/releases/tag/1.2.1) in WordPress 6.5.
 
 ## 1.2.0

--- a/vip-decoupled.php
+++ b/vip-decoupled.php
@@ -5,7 +5,7 @@
  * Description: Plugin bundle to quickly provide a decoupled WordPress setup.
  * Author: WordPress VIP
  * Text Domain: vip-decoupled-bundle
- * Version: 1.2.0
+ * Version: 1.2.1
  * Requires at least: 5.9.0
  * Tested up to: 6.4.0
  * Requires PHP: 7.4


### PR DESCRIPTION
## Description

Two updates in this release:

- [**Add preview URL filter**](https://github.com/Automattic/vip-decoupled-bundle/pull/81): Adds the ability to modify preview URL destinations.
- [**Update VIP Block Data API v1.2.1**](https://github.com/Automattic/vip-decoupled-bundle/pull/82): Update the VIP Block Data API to `1.2.1` which [supports `rich-text` attributes](https://github.com/Automattic/vip-block-data-api/releases/tag/1.2.1) in WordPress 6.5.