### PR TITLE
Avoid core/image PHP warnings

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -57,7 +57,7 @@ function get_content_blocks( $post_model ) {
  * @return array
  */
 function transform_block_attributes( $block ) {
-	if ( 'core/image' === $block['name'] ) {
+	if ( ! empty( $block['name'] ) && 'core/image' === $block['name'] && ! empty( $block['attributes']['id'] ) ) {
 		$attachment_metadata = \wp_get_attachment_metadata( $block['attributes']['id'] );
 
 		$block['attributes']['src']            = \wp_get_attachment_url( $block['attributes']['id'] );


### PR DESCRIPTION
## Description

Fixing PHP warnings when empty core/image blocks are used inside the WordPress Block editor.

Fixes: https://github.com/Automattic/vip-decoupled-bundle/issues/89

## Steps to Test

1. Add an empty `core/image` to a post (as shown in the below screenshot).
2. Go to the GraphQL IDE and execute the below example query. Please set a relevant `id` based on your instance.
3. Check the debug logs of your instance, and warnings shouldn't appear. 
4. Set an attachment to the empty image block and ensure attributes like `originalHeight` are available when using the same query (check the **attachment attributes** screenshot).

### Screenshots

**core/image**

<img width="616" alt="empty-core-image" src="https://github.com/user-attachments/assets/cd70dc6b-99df-4660-90c0-bd210f20fc82" />

**attachment attributes**

<img width="616" alt="attachment-attributes" src="https://github.com/user-attachments/assets/a99b1446-e572-44cb-bfaf-d6c55e6a6e54" />



### Example GraphQL Query

```graphql
query GetPostContentBlocks {
  post(id: 6, idType: DATABASE_ID) {
    contentBlocks {
      blocks {
        tagName
        name
        attributes {
          name
          value
        }
      }
    }
  }
}
```